### PR TITLE
Make the dependency on kubernetes-cli optional.

### DIFF
--- a/Formula/kns.rb
+++ b/Formula/kns.rb
@@ -6,7 +6,7 @@ class Kns < Formula
   head "https://github.com/blendle/kns.git"
 
   depends_on "fzf"
-  depends_on "kubernetes-cli"
+  depends_on "kubernetes-cli" => [:optional, "with-kubectl"]
 
   def install
     bin.install "./kns"


### PR DESCRIPTION
Made the dependency on kubernetes-cli optional seeing people could install kubectl using gcloud or curl.

As suggested by @JeanMertz https://github.com/blendle/homebrew-blendle/pull/1#issuecomment-299494875