### PR TITLE
Upgrade bnl-platform-command to v0.2.1

### DIFF
--- a/Formula/bnl-platform-command.rb
+++ b/Formula/bnl-platform-command.rb
@@ -2,10 +2,10 @@ class BnlPlatformCommand < Formula
   desc "Platform related bnl commands"
   homepage "https://github.com/blendle/bnl-platform-command"
   url "git@github.com:blendle/bnl-platform-command.git",
-    version: "v0.2.0",
-    revision: "7adc721e2c4b89a8db5686ef91e515f87dafa6d0",
+    version: "v0.2.1",
+    revision: "daeef9da8b3c142fba14421777c2f9b16c65c976",
     using: :git
-  version "7adc721e2c4b89a8db5686ef91e515f87dafa6d0"
+  version "v0.2.1"
   head "git@github.com:blendle/bnl-platform-command.git", using: :git
 
   depends_on "blendle/blendle/bnl" => :recommended


### PR DESCRIPTION
Ignore /health while running stern commands