### PR TITLE
Update `kns` to the latest master

### DIFF
--- a/Formula/kns.rb
+++ b/Formula/kns.rb
@@ -1,8 +1,8 @@
 class Kns < Formula
   desc "quick Kubernetes Namespace Switcher"
   homepage "https://github.com/blendle/kns"
-  url "https://github.com/blendle/kns.git", :revision => "1126226c46004694cb472a73731eafae071d6016"
-  version "1126226c46004694cb472a73731eafae071d6016"
+  url "https://github.com/blendle/kns.git", :revision => "ac3d5bdb3fc5ad94899b2cc278682c7eba9f3deb"
+  version "ac3d5bdb3fc5ad94899b2cc278682c7eba9f3deb"
   head "https://github.com/blendle/kns.git"
 
   depends_on "fzf"


### PR DESCRIPTION
Some minor improvements, skips a dependency and doens't show the double namespace.
See: https://github.com/blendle/kns/pull/3