### PR TITLE
Using the new <<~ to mute a warning

### DIFF
--- a/Formula/kns.rb
+++ b/Formula/kns.rb
@@ -12,7 +12,7 @@ class Kns < Formula
     bin.install "./kns"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     I really recommend this alias:
       $ alias k=kubectl
     EOS


### PR DESCRIPTION
Got this warning:
```
Warning: Calling <<-EOS.undent is deprecated!
Use <<~EOS instead.
/usr/local/Homebrew/Library/Taps/blendle/homebrew-blendle/Formula/kns.rb:18:in `caveats'
Please report this to the blendle/blendle tap!
```

This change should fix that.