### PR TITLE
Update kns and include the ktx command.

### DIFF
--- a/Formula/kns.rb
+++ b/Formula/kns.rb
@@ -1,15 +1,17 @@
 class Kns < Formula
   desc "quick Kubernetes Namespace Switcher"
   homepage "https://github.com/blendle/kns"
-  url "https://github.com/blendle/kns.git", :revision => "ac3d5bdb3fc5ad94899b2cc278682c7eba9f3deb"
-  version "ac3d5bdb3fc5ad94899b2cc278682c7eba9f3deb"
+  url "https://github.com/blendle/kns.git", :revision => "9e30d8df96dc864383845ea5a12cd460f33166fa"
+  version "9e30d8df96dc864383845ea5a12cd460f33166fa"
   head "https://github.com/blendle/kns.git"
 
   depends_on "fzf"
   depends_on "kubernetes-cli" => :optional
 
   def install
-    bin.install "./kns"
+    bin.install "bin/kns"
+    bin.install "bin/ktx"
+    prefix.install "helpers"
   end
 
   def caveats; <<~EOS

--- a/Formula/kns.rb
+++ b/Formula/kns.rb
@@ -1,5 +1,5 @@
 class Kns < Formula
-  desc "quick Kubernetes Namespace Switcher"
+  desc "Quick Kubernetes Namespace and Context Switchers"
   homepage "https://github.com/blendle/kns"
   url "https://github.com/blendle/kns.git", :revision => "9e30d8df96dc864383845ea5a12cd460f33166fa"
   version "9e30d8df96dc864383845ea5a12cd460f33166fa"


### PR DESCRIPTION
This update includes two pull-requests:
 - https://github.com/blendle/kns/pull/4
 - https://github.com/blendle/kns/pull/6

It introduces the new `ktx` command to switch between Kubernetes contexts.