### PR TITLE
Update Travis CI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: objective-c
+os: osx
+osx_image: xcode12.5
 before_install:
   - brew update >/dev/null
 script:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Blendle Homebrew tap
 
-[![Build Status](https://travis-ci.org/blendle/homebrew-blendle.svg?branch=master)](https://travis-ci.org/blendle/homebrew-blendle)
+[![Build Status](https://travis-ci.com/blendle/homebrew-blendle.svg?branch=master)](https://travis-ci.com/github/blendle/homebrew-blendle)
 
 Homebrew tap for tools not (yet) submitted to Homebrew Core.
 


### PR DESCRIPTION
This updates the Travis CI setup.

travis.org does not work anymore, so I migrated the project to travis.com.
Also I had to buy extra credits for it to run on osx and added the latest version of osx as a requirement, otherwise brew gives all kinds of errors: https://travis-ci.com/github/blendle/homebrew-blendle/builds/233780682

Also updated the link to the builds in the ReadMe.

I manually started a build with these settings and it worked (failed the tests instead of erroring in the setup process): https://travis-ci.com/github/blendle/homebrew-blendle/builds/233862982