### PR TITLE
Kubecrt update to v0.9.2

### DIFF
--- a/Formula/kubecrt.rb
+++ b/Formula/kubecrt.rb
@@ -2,8 +2,8 @@ class Kubecrt < Formula
   desc "Convert Helm charts to Kubernetes resources"
   homepage "https://github.com/blendle/kubecrt"
   url "https://github.com/blendle/kubecrt.git",
-    tag:      "v0.9.1",
-    revision: "56be1141b406552ed043c29a87950cd519f7bbc6"
+    tag:      "v0.9.2",
+    revision: "84ecbcfd325597e368cca640b734fcae3232b37d"
   head "https://github.com/blendle/kubecrt.git"
 
   depends_on "go" => :build

--- a/Formula/kubecrt.rb
+++ b/Formula/kubecrt.rb
@@ -2,23 +2,16 @@ class Kubecrt < Formula
   desc "Convert Helm charts to Kubernetes resources"
   homepage "https://github.com/blendle/kubecrt"
   url "https://github.com/blendle/kubecrt.git",
-    tag:      "v0.9.0",
-    revision: "aa3c0eb7aac3b8a98c4a5b80729398a74a78fb84"
+    tag:      "v0.9.1",
+    revision: "56be1141b406552ed043c29a87950cd519f7bbc6"
   head "https://github.com/blendle/kubecrt.git"
 
-  bottle do
-    root_url "https://homebrew-blendle.storage.googleapis.com"
-    sha256 cellar: :any_skip_relocation, high_sierra: "18f2f3a15a9b17c5e12076752e4050a8200db8b9692a1aa3928be5ebad87a4a4"
-  end
-
-  depends_on "dep" => :build
   depends_on "go" => :build
 
   def install
     ENV["GOPATH"] = buildpath
     buildpath.join("src/github.com/blendle/kubecrt").install buildpath.children
     cd "src/github.com/blendle/kubecrt" do
-      system "dep", "ensure", "-vendor-only"
       system "make", "build"
       bin.install "bin/kubecrt"
     end


### PR DESCRIPTION
This includes the change of the stableRepository url: https://github.com/blendle/kubecrt/commit/2dcb193eb85e8ea4c80c67e7fa9312b3e16266ec

I removed the old bottle, but can't get it to build a new bottle yet since I get these errors.

```
brew bottle kubecrt --root-url=https://homebrew-blendle.storage.googleapis.com
Error: Formula not installed or up-to-date: blendle/blendle/kubecrt
```