### PR TITLE
Fix error caused by removal of String#undent

### DIFF
--- a/Formula/bnl.rb
+++ b/Formula/bnl.rb
@@ -15,8 +15,7 @@ class Bnl < Formula
     bin.install "./bnl-help"
   end
 
-  def caveats
-    ohai <<~EOS
+  def caveats; <<~EOS
       For autocompletion try this:
 
       zsh:

--- a/Formula/bnl.rb
+++ b/Formula/bnl.rb
@@ -16,7 +16,7 @@ class Bnl < Formula
   end
 
   def caveats
-    ohai <<-EOS.undent
+    ohai <<~EOS
       For autocompletion try this:
 
       zsh:


### PR DESCRIPTION
Swaps out `String#undent` for `<<~EOF`. Also removes the unneeded use of `ohai` in the caveats section which breaks JSON output.

Background
------------

Homebrew removed their monkeypatch of `String#undent` in Homebrew/brew#4392 which is causing this error:

```
$ brew info bnl
blendle/blendle/bnl: stable b2e7a94623b490dcbe5d5c2cb29c68d26433725a, HEAD
Blendle Command-Line Tools
https://github.com/blendle/bnl
Not installed
From: https://github.com/blendle/homebrew-blendle/blob/HEAD/Formula/bnl.rb
==> Options
--HEAD
	Install HEAD version
Error: undefined method `undent' for #<String:0x000000013d8c3c58>
Did you mean?  undef
               indent
               indent!
/opt/homebrew/Library/Taps/blendle/homebrew-blendle/Formula/bnl.rb:19:in `caveats'
/opt/homebrew/Library/Homebrew/caveats.rb:23:in `caveats'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/forwardable.rb:224:in `empty?'
/opt/homebrew/Library/Homebrew/cmd/info.rb:335:in `info_formula'
/opt/homebrew/Library/Homebrew/cmd/info.rb:153:in `block in print_info'
/opt/homebrew/Library/Homebrew/cmd/info.rb:148:in `each'
/opt/homebrew/Library/Homebrew/cmd/info.rb:148:in `each_with_index'
/opt/homebrew/Library/Homebrew/cmd/info.rb:148:in `print_info'
/opt/homebrew/Library/Homebrew/cmd/info.rb:111:in `info'
/opt/homebrew/Library/Homebrew/brew.rb:93:in `<main>'
```
